### PR TITLE
Add Backstage catalog info and docs tree to project: test-adrs

### DIFF
--- a/'docs'/docs/architecture-decisions/adr000-template.md
+++ b/'docs'/docs/architecture-decisions/adr000-template.md
@@ -1,0 +1,23 @@
+---
+id: adrs-adr000
+title: 'ADR000: [TITLE]'
+# prettier-ignore
+description: Architecture Decision Record (ADR) for [TITLE] [DESCRIPTION]
+---
+
+<!-- These documents have names that are short noun phrases. For example, "ADR001: Deployment on Ruby on Rails 3.0.10" or "ADR009: LDAP for Multitenant Integration" -->
+
+## Context
+
+<!--
+This section describes the forces at play, including technological, political, social, and project local. These forces are probably in tension, and should be called out as such. The language in this section is value-neutral. It is simply describing facts. -->
+
+## Decision
+
+<!-- This section describes our response to these forces. It is stated in full sentences, with active voice. "We will ..." -->
+
+## Consequences
+
+<!-- This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future. -->
+
+<!-- This template is taken from a blog post by Michael Nygard http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions -->

--- a/'docs'/docs/architecture-decisions/index.md
+++ b/'docs'/docs/architecture-decisions/index.md
@@ -1,0 +1,36 @@
+---
+id: adrs-overview
+title: Architecture Decision Records (ADR)
+sidebar_label: Overview
+# prettier-ignore
+description: Overview of Architecture Decision Records (ADR)
+---
+
+The substantial architecture decisions made in the Labels Repo project live here.
+For more information about ADRs, when to write them, and why, please see
+[this blog post](https://engineering.atspotify.com/2020/04/14/when-should-i-write-an-architecture-decision-record/).
+
+Records are never deleted but can be marked as superseded by new decisions or
+deprecated.
+
+Records should be stored under the `docs/internal/architecture-decisions` directory.
+
+## Contributing
+
+### Creating an ADR
+
+- Copy `docs/internal/architecture-decisions/adr000-template.md` to
+  `docs/internal/architecture-decisions/adr000-my-decision.md` (my-decision should be
+  descriptive. Do not assign an ADR number.)
+- Fill in the ADR following the guidelines in the template
+- Submit a pull request
+- Address and integrate feedback from the community
+- Eventually, assign a number
+- Add the path of the ADR to the
+  [`mkdocs.yml`](https://github.com/grafana/gops-labels/docs/internal/mkdocs.yml)
+- Merge the pull request
+
+## Superseding an ADR
+
+If an ADR supersedes an older ADR then the status of the older ADR is changed to
+"superseded by ADR-XXXX", and links to the new ADR.

--- a/'docs'/docs/blog/index.md
+++ b/'docs'/docs/blog/index.md
@@ -1,0 +1,2 @@
+# The test-adrs Blog
+

--- a/'docs'/docs/blog/posts/first-post.md
+++ b/'docs'/docs/blog/posts/first-post.md
@@ -1,0 +1,9 @@
+---
+date: 2023-01-31 
+categories:
+  - Hello World
+toc:
+---
+
+# First Post!
+This is the text!

--- a/'docs'/docs/blog/posts/second-post.md
+++ b/'docs'/docs/blog/posts/second-post.md
@@ -1,0 +1,10 @@
+---
+date: 2023-01-31 
+categories:
+  - Hello World
+  - Backstage
+toc:
+---
+
+# Second Post!
+This is the second post text!

--- a/'docs'/docs/index.md
+++ b/'docs'/docs/index.md
@@ -1,0 +1,4 @@
+# Welcome to test-adrs!
+
+This is a placeholder for your internal team documentation. See [Grafana Incident](https://backstage.grafana-ops.net/docs/default/component/grafana-incident) set of docs on Backstage for an interesting example.
+

--- a/'docs'/mkdocs.yml
+++ b/'docs'/mkdocs.yml
@@ -1,0 +1,16 @@
+# To run locally
+# npx techdocs-cli serve -v -c docs/internal/mkdocs.yml
+# 
+site_name: ' Internal Documentation'
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+nav:
+  - Home: 'index.md'
+  - Architectural Decisions:
+    - Introduction: architecture-decisions/index.md
+
+plugins:
+  - techdocs-core

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,15 +6,24 @@ metadata:
   name: test-adrs
   title: test-adrs
   description: |
-    
+    Testing adr rendering
   links:
     - title: GitHub Private Repo
       url: https://github.com/nafisat2/test-adrs
+    # - title: Slack Channel
+    #   url: 
+    # - title: SLO Dashboard
+    #   url: 
   annotations:
     backstage.io/techdocs-ref: dir:./
-    backstage.io/adr-location: docs/docs/architecture-decisions
+    backstage.io/adr-location: /docs/architecture-decisions
     github.com/project-slug: nafisat2/test-adrs
 spec:
-  type: library
+  type: 
+  domain: 
   owner: user:default/nafisat2
+  system: 
   lifecycle: production
+  dependsOn:
+
+  


### PR DESCRIPTION
# Add Backstage catalog and docs tree
This PR adds the necessary into the repo to enable Backstage to describe this component.
You will still need to tag the repo with the appropriate topics to make it show up in the catalog.
Please see [this link](https://backstage.grafana-ops.net/docs/default/component/grafana-backstage/user-guides/registering-software-catalog-entities/#2-tag-your-repository-with-backstage-include)
for instructions on how to tag your repo.
