### PR TITLE
Add Backstage catalog info and docs tree to project: test-adrs

### DIFF
--- a/.github/workflows/publish-internal-docs.yaml
+++ b/.github/workflows/publish-internal-docs.yaml
@@ -1,0 +1,22 @@
+name: Publish TechDocs
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - './docs/internal/docs/**'
+      - './docs/internal/docs/mkdocs.yml'
+      - 'catalog-info.yaml'
+      - '.github/workflows/publish-techdocs.yaml'
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+jobs:
+  publish-docs:
+    uses: grafana/shared-workflows/.github/workflows/publish-techdocs.yaml@main
+    secrets: inherit
+    with:
+      namespace: default
+      kind: component
+      name: test-adrs
+      default-working-directory: ./docs/internal

--- a/__mkdocs__.yml
+++ b/__mkdocs__.yml
@@ -1,0 +1,14 @@
+# To run locally
+# npx techdocs-cli serve -v -c ./docs/internal/mkdocs.yml
+# 
+site_name: 'test-adrs Internal Documentation'
+repo_url: https://github.com/nafisat2/test-adrs
+edit_uri: edit/main/docs/internal/docs
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+
+plugins:
+  - techdocs-core

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,19 +3,10 @@ kind: Component
 metadata:
   name: test-adrs
   title: test-adrs
-  description: A repository for testing ADR rendering
-  links:
-    - title: GitHub Private Repo
-      url: https://github.com/nafisat2/test-adrs
-    # - title: Slack Channel
-    #   url: 
-    # - title: SLO Dashboard
-    #   url: 
   annotations:
-    backstage.io/techdocs-ref: dir:./
-    backstage.io/adr-location: docs/architecture-decisions
+    backstage.io/techdocs-ref: dir:./docs/internal
     github.com/project-slug: nafisat2/test-adrs
 spec:
   type: service
-  owner: nafisat2
+  owner: user:default/nafisat2
   lifecycle: production


### PR DESCRIPTION
# Add Backstage catalog and docs tree
This PR adds the necessary into the repo to enable Backstage to describe this service.
You will still need to tag the repo with the appropriate topics to make it show up in the catalog.
Please see [this link](https://backstage.grafana-ops.net/docs/default/component/grafana-backstage/user-guides/registering-software-catalog-entities/#2-tag-your-repository-with-backstage-include)
for instructions on how to tag your repo.
