### PR TITLE
Register Component into Software Catalog and setup TechDocs publishing

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-adrs
   title: test-adrs
   annotations:
-    backstage.io/adr-location: ./docs/internal/adr
+    backstage.io/adr-location: ./docs/internal/docs/adr
     backstage.io/techdocs-ref: dir:./docs/internal
     github.com/project-slug: nafisat2/test-adrs
 spec:

--- a/docs/internal/docs/adr/.template.md
+++ b/docs/internal/docs/adr/.template.md
@@ -1,0 +1,79 @@
+---
+# These are optional elements. Feel free to remove any of them.
+status: "{proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}"
+date: {YYYY-MM-DD when the decision was last updated}
+deciders: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+---
+# {short title of solved problem and solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+ You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because
+{justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+### Confirmation
+
+{Describe how the implementation of/compliance with the ADR is confirmed. E.g., by a review or an ArchUnit test.
+ Although we classify this element as optional, it is included in most ADRs.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or
+ document the team agreement on the decision and/or
+ define when/how this decision the decision should be realized and if/when it should be re-visited.
+Links to other decisions and resources might appear here as well.}

--- a/docs/internal/docs/adr/index.md
+++ b/docs/internal/docs/adr/index.md
@@ -1,0 +1,33 @@
+---
+id: adrs-overview
+title: Architecture Decision Records (ADR)
+sidebar_label: Overview
+# prettier-ignore
+description: Overview of Architecture Decision Records (ADR)
+---
+
+The substantial architecture decisions made in the test-adrs project live here.
+For more information about ADRs, when to write them, and why, please see
+[this blog post](https://engineering.atspotify.com/2020/04/14/when-should-i-write-an-architecture-decision-record/).
+
+Records are never deleted but can be marked as superseded by new decisions or
+deprecated.
+
+Records should be stored under the `./docs/internal/docs/adr` directory.
+
+## Contributing
+
+### Creating an ADR
+
+- Copy `./docs/internal/docs/adr/.template.md` to
+  `./docs/internal/docs/adr/YYYYMMDD-title.md` (title should be
+  descriptive.)
+- Fill in the ADR following the guidelines in the template
+- Submit a pull request
+- Address and integrate feedback from the community
+- Merge the pull request
+
+## Superseding an ADR
+
+If an ADR supersedes an older ADR then the status of the older ADR is changed to
+"superseded by YYYYMMDD-title", and links to the new ADR.

--- a/docs/internal/docs/blog/index.md
+++ b/docs/internal/docs/blog/index.md
@@ -1,0 +1,2 @@
+# The test-adrs Blog
+

--- a/docs/internal/docs/blog/posts/first-post.md
+++ b/docs/internal/docs/blog/posts/first-post.md
@@ -1,0 +1,9 @@
+---
+date: 2023-01-31 
+categories:
+  - Hello World
+toc:
+---
+
+# First Post!
+This is the text!

--- a/docs/internal/docs/blog/posts/second-post.md
+++ b/docs/internal/docs/blog/posts/second-post.md
@@ -1,0 +1,10 @@
+---
+date: 2023-01-31 
+categories:
+  - Hello World
+  - Backstage
+toc:
+---
+
+# Second Post!
+This is the second post text!

--- a/docs/internal/docs/index.md
+++ b/docs/internal/docs/index.md
@@ -1,0 +1,4 @@
+# Welcome to test-adrs!
+
+This is a placeholder for your internal team documentation. See [Grafana Incident](https://backstage.grafana-ops.net/docs/default/component/grafana-incident) set of docs on Backstage for an interesting example.
+


### PR DESCRIPTION
# Register Component into Software Catalog and setup TechDocs publishing
This PR adds the necessary files to the repo to:

* enable Grafana Backstage to catalog this service
* set up TechDocs site and publishing

You will still need to tag the repo with the appropriate topics to make it show up in the catalog.
Please see [this link](https://backstage.grafana-ops.net/docs/default/component/grafana-backstage/user-guides/registering-software-catalog-entities/#2-tag-your-repository-with-backstage-include) for instructions on how to tag your repo.
