### PR TITLE
Register Component into Software Catalog and setup TechDocs publishing

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -4,13 +4,13 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
-      - 'docs/mkdocs.yml'
+      - './docs/**'
+      - './docs/mkdocs.yml'
       - 'catalog-info.yaml'
       - '.github/workflows/publish-techdocs.yaml'
 concurrency:
-    group: '-'
-    cancel-in-progress: true
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 jobs:
   publish-docs:
     uses: grafana/shared-workflows/.github/workflows/publish-techdocs.yaml@main
@@ -19,4 +19,4 @@ jobs:
       namespace: default
       kind: component
       name: test-adrs
-      default-working-directory: docs/internal
+      default-working-directory: .

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,7 @@ metadata:
   name: test-adrs
   title: test-adrs
   annotations:
-    backstage.io/adr-location: ./docs/internal/docs/adr
-    backstage.io/techdocs-ref: dir:./docs/internal
+    backstage.io/techdocs-ref: dir:.
     github.com/project-slug: nafisat2/test-adrs
 spec:
   type: service

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,3 @@
 
 This is a placeholder for your internal team documentation. See [Grafana Incident](https://backstage.grafana-ops.net/docs/default/component/grafana-incident) set of docs on Backstage for an interesting example.
 
-Updating documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
 # To run locally
-# npx techdocs-cli serve -v -c ./docs/internal/mkdocs.yml
+# npx techdocs-cli serve -v -c ./mkdocs.yml
 # 
 site_name: 'test-adrs Internal Documentation'
 repo_url: https://github.com/nafisat2/test-adrs
-edit_uri: edit/main/docs/internal/docs
+edit_uri: edit/main/docs
 
 theme:
   name: material
@@ -12,5 +12,3 @@ theme:
 
 plugins:
   - techdocs-core
-  - blog:
-      post_url_format: "{date}/{slug}"


### PR DESCRIPTION
# Register Component into Software Catalog and setup TechDocs publishing
This PR adds the necessary files to the repo to:

* enable Grafana Backstage to catalog this service
* set up TechDocs site and publishing

You will still need to tag the repo with the appropriate topics to make it show up in the catalog.
Please see [this link](https://backstage.grafana-ops.net/docs/default/component/grafana-backstage/user-guides/registering-software-catalog-entities/#2-tag-your-repository-with-backstage-include) for instructions on how to tag your repo.
